### PR TITLE
Feat: Add docker file

### DIFF
--- a/spring/fitqa-spring-java/Dockerfile
+++ b/spring/fitqa-spring-java/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-alpine
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
도커 빌드를 위한 Dockerfile을 만들었다.

[참고 링크](https://spring.io/guides/gs/spring-boot-docker/)

# 도커 빌드방법
1. `./gradlew build` (터미널에서 하거나 `Android Studio`에서 하면 됨)
2. `docker build --build-arg JAR_FILE=build/libs/\*.jar -t springio/gs-spring-boot-docker .`
3. `docker run -p 8080:8080 -t springio/gs-spring-boot-docker` (테스트 해보기)
4. `docker push ymj02349/fitqa-spring-java:tagname`