### PR TITLE
Update trainer domain

### DIFF
--- a/spring/fitqa-spring-java/http-test/trainer-api.http
+++ b/spring/fitqa-spring-java/http-test/trainer-api.http
@@ -27,12 +27,51 @@ Content-Type: application/json
 ###
 # 트레이너의 관심 부위 정보를 변경합니다
 
-PUT http://localhost:8080/api/v1/trainers/trn_Fb1Q9MPItiVTnkiY/interestAreas
+PUT http://localhost:8080/api/v1/trainers/trn_EfF1W4nfWsOoDx49/interestAreas
 Content-Type: application/json
 
 {
   "interestAreas": [
     "LOWER",
     "BACK"
+  ]
+}
+
+###
+# 트레이너의 정보를 변경합니다.
+
+PUT http://localhost:8080/api/v1/trainers/trn_EfF1W4nfWsOoDx49/
+Content-Type: application/json
+
+{
+  "name": "오상헌333",
+  "style": "BODY_BUILDING",
+  "introduceTitle": "소개 제목을 변경합니다777",
+  "introduceContext": "소개 내용을 변경합니다777",
+  "careers": [
+    {
+      "description": "1번 경력입니다.",
+      "type": "CAREER"
+    }
+  ],
+  "feedbackPrices": [
+    {
+      "area": "LOWER",
+      "price": 6000
+    }
+  ],
+  "interestAreas": [
+    {
+      "interestArea": "CHEST"
+    },
+    {
+      "interestArea": "SHOULDER"
+    }
+  ],
+  "sns": [
+    {
+      "snsUrl": "Sns 3 Url",
+      "snsType": "INSTAGRAM"
+    }
   ]
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/application/trainer/TrainerFacade.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/application/trainer/TrainerFacade.java
@@ -34,7 +34,13 @@ public class TrainerFacade {
   }
 
   public TrainerInfo.Main updateTrainerInterestAreas(String trainerToken,
-                                                     TrainerCommand.UpdateTrainersByInterestAreas updateInterestAreas) {
+                                                     TrainerCommand.UpdateTrainerByInterestAreas updateInterestAreas) {
     return trainerService.updateTrainerInterestAreas(trainerToken, updateInterestAreas);
+  }
+
+  public TrainerInfo.Main updateTrainerInfo(String trainerToken,
+                                            TrainerCommand.UpdateTrainerInfo updateTrainerInfo) {
+    return trainerService.updateTrainerInfo(trainerToken, updateTrainerInfo);
+
   }
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/TrainerCommand.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/TrainerCommand.java
@@ -1,12 +1,14 @@
 package com.cocovo.fitqaspringjava.domain.trainer;
 
+import com.cocovo.fitqaspringjava.domain.common.entity.type.SnsType;
 import com.cocovo.fitqaspringjava.domain.common.entity.type.WorkOutType;
-import com.cocovo.fitqaspringjava.domain.trainer.entity.Trainer;
+import com.cocovo.fitqaspringjava.domain.trainer.entity.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class TrainerCommand {
 
@@ -32,7 +34,88 @@ public class TrainerCommand {
   @Getter
   @Builder
   @ToString
-  public static class UpdateTrainersByInterestAreas {
+  public static class UpdateTrainerByInterestAreas {
     private final List<WorkOutType.InterestArea> interestAreas;
+  }
+
+  @Getter
+  @Builder
+  @ToString
+  public static class UpdateTrainerInfo {
+    private final String name;
+    private final WorkOutType.Style style;
+    private final String introduceTitle;
+    private final String introduceContext;
+    private final List<UpdateTrainerCareer> careers;
+    private final List<UpdateFeedbackPrice> feedbackPrices;
+    private final List<UpdateInterestArea> interestAreas;
+    private final List<UpdateSns> sns;
+
+    public Trainer toEntity() {
+      var trainerCareers = careers.isEmpty() ? null :
+          careers.stream().map(updateTrainerCareer -> updateTrainerCareer.toEntity())
+              .collect(Collectors.toList());
+      var trainerFeedbackPrices = feedbackPrices.isEmpty() ? null :
+          feedbackPrices.stream().map(updateFeedbackPrice -> updateFeedbackPrice.toEntity())
+              .collect(Collectors.toList());
+      var trainerInterestAreas = interestAreas.isEmpty() ? null :
+          interestAreas.stream().map(updateInterestArea -> updateInterestArea.toEntity())
+              .collect(Collectors.toList());
+      var trainerSns =
+          sns.stream().map(updateSns -> updateSns.toEntity()).collect(Collectors.toList());
+
+      return Trainer.builder().name(name).style(style).introduceTitle(introduceTitle)
+          .introduceContext(introduceContext).careers(trainerCareers)
+          .feedbackPrices(trainerFeedbackPrices).interestAreas(trainerInterestAreas).sns(trainerSns)
+          .build();
+    }
+  }
+
+  @Getter
+  @Builder
+  @ToString
+  public static class UpdateTrainerCareer {
+    private final String description;
+    private final TrainerCareer.Type type;
+
+    public TrainerCareer toEntity() {
+      return TrainerCareer.builder().description(description).type(type).build();
+    }
+  }
+
+  @Getter
+  @Builder
+  @ToString
+  public static class UpdateFeedbackPrice {
+    private final WorkOutType.InterestArea area;
+    private final Integer price;
+
+    public TrainerFeedbackPrice toEntity() {
+      return TrainerFeedbackPrice.builder().interestArea(area).price(price)
+          .build();
+    }
+  }
+
+  @Getter
+  @Builder
+  @ToString
+  public static class UpdateInterestArea {
+    private final WorkOutType.InterestArea interestArea;
+
+    public TrainerInterestArea toEntity() {
+      return TrainerInterestArea.builder().interestArea(interestArea).build();
+    }
+  }
+
+  @Getter
+  @Builder
+  @ToString
+  public static class UpdateSns {
+    private final SnsType.Type snsType;
+    private final String snsUrl;
+
+    public TrainerSns toEntity() {
+      return TrainerSns.builder().snsType(snsType).snsUrl(snsUrl).build();
+    }
   }
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/TrainerInfo.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/TrainerInfo.java
@@ -58,11 +58,11 @@ public class TrainerInfo {
   @Getter
   @ToString
   public static class TrainerFeedbackPriceInfo {
-    private final WorkOutType.InterestArea interestArea;
+    private final WorkOutType.InterestArea area;
     private final Integer price;
 
     public TrainerFeedbackPriceInfo(TrainerFeedbackPrice trainerFeedbackPrice) {
-      this.interestArea = trainerFeedbackPrice.getInterestArea();
+      this.area = trainerFeedbackPrice.getInterestArea();
       this.price = trainerFeedbackPrice.getPrice();
     }
   }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/component/TrainerUpdater.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/component/TrainerUpdater.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface TrainerUpdater {
   boolean updateTrainerInterestAreas(Trainer trainer,
                                      List<WorkOutType.InterestArea> updateInterestAreas);
+
+  boolean updateTrainerInfo(Trainer trainer, Trainer initUpdateTrainer);
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/entity/Trainer.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/entity/Trainer.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
+import java.util.Iterator;
 import java.util.List;
 
 @Slf4j
@@ -42,32 +43,44 @@ public class Trainer extends BaseEntity {
 
   private Integer likesCount;
 
-  @OneToMany(fetch = FetchType.LAZY, mappedBy = "trainer", cascade = CascadeType.PERSIST)
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "trainer", cascade = {CascadeType.PERSIST,
+      CascadeType.REMOVE})
   private List<TrainerImage> images = Lists.newArrayList();
 
-  @OneToMany(fetch = FetchType.LAZY, mappedBy = "trainer", cascade = CascadeType.PERSIST)
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "trainer", cascade = {CascadeType.PERSIST,
+      CascadeType.REMOVE}, orphanRemoval = true)
   private List<TrainerCareer> careers = Lists.newArrayList();
 
-  @OneToMany(fetch = FetchType.LAZY, mappedBy = "trainer", cascade = CascadeType.PERSIST)
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "trainer", cascade = {CascadeType.PERSIST,
+      CascadeType.REMOVE}, orphanRemoval = true)
   private List<TrainerFeedbackPrice> feedbackPrices = Lists.newArrayList();
 
-  @OneToMany(fetch = FetchType.LAZY, mappedBy = "trainer", cascade = CascadeType.PERSIST)
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "trainer", cascade = {CascadeType.PERSIST,
+      CascadeType.REMOVE}, orphanRemoval = true)
   private List<TrainerInterestArea> interestAreas = Lists.newArrayList();
 
-  @OneToMany(fetch = FetchType.LAZY, mappedBy = "trainer", cascade = CascadeType.PERSIST)
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "trainer", cascade = {CascadeType.PERSIST,
+      CascadeType.REMOVE}, orphanRemoval = true)
   private List<TrainerSns> sns = Lists.newArrayList();
 
   @Builder
-  public Trainer(String name, WorkOutType.Style style) {
+  public Trainer(String name, WorkOutType.Style style, String introduceTitle,
+                 String introduceContext, List<TrainerCareer> careers,
+                 List<TrainerFeedbackPrice> feedbackPrices, List<TrainerInterestArea> interestAreas,
+                 List<TrainerSns> sns) {
     if (StringUtils.isEmpty(name))
       throw new InvalidParamException("name is empty");
 
     this.trainerToken = TokenGenerator.randomCharacterWithPrefix(TRAINER_PREFIX);
     this.name = name;
     this.style = style;
+    this.introduceTitle = introduceTitle;
+    this.introduceContext = introduceContext;
+    this.careers = careers;
+    this.feedbackPrices = feedbackPrices;
+    this.interestAreas = interestAreas;
+    this.sns = sns;
     this.likesCount = 0;
-    this.introduceTitle = "";
-    this.introduceContext = "";
     this.representativeCareer = "";
     this.representativeFootprints = "";
   }
@@ -75,4 +88,98 @@ public class Trainer extends BaseEntity {
   public void addInterestArea(TrainerInterestArea newTrainerInterestArea) {
     interestAreas.add(newTrainerInterestArea);
   }
+
+  public Trainer updateName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public Trainer updateStyle(WorkOutType.Style style) {
+    this.style = style;
+    return this;
+  }
+
+  public Trainer updateIntroduce(String introduceTitle, String introduceContext) {
+    this.introduceTitle = introduceTitle;
+    this.introduceContext = introduceContext;
+    return this;
+  }
+
+  public Trainer updateCareers(List<TrainerCareer> newCareers) {
+    deleteCareers();
+    newCareers.forEach(trainerCareer -> {
+      trainerCareer.setTrainer(this);
+    });
+    careers.addAll(newCareers);
+    return this;
+  }
+
+  public Trainer updateFeedbackPrices(List<TrainerFeedbackPrice> newFeedbackPrices) {
+    deleteFeedbackPrices();
+    newFeedbackPrices.forEach(trainerFeedbackPrice -> {
+      trainerFeedbackPrice.setTrainer(this);
+    });
+    feedbackPrices.addAll(newFeedbackPrices);
+    return this;
+  }
+
+  public Trainer updateInterestAreas(List<TrainerInterestArea> newInterestAreas) {
+    deleteInterestAreas();
+    newInterestAreas.forEach(trainerInterestArea -> {
+      trainerInterestArea.setTrainer(this);
+    });
+    interestAreas.addAll(newInterestAreas);
+    return this;
+  }
+
+  public Trainer updateSns(List<TrainerSns> newSns) {
+    deleteSns();
+    newSns.forEach(trainerSns -> {
+      trainerSns.setTrainer(this);
+    });
+    sns.addAll(newSns);
+    return this;
+  }
+
+  public void deleteCareers() {
+    Iterator<TrainerCareer> it = careers.iterator();
+
+    while (it.hasNext()) {
+      TrainerCareer next = it.next();
+      next.setTrainer(null);
+      it.remove();
+    }
+  }
+
+  public void deleteFeedbackPrices() {
+    Iterator<TrainerFeedbackPrice> it = feedbackPrices.iterator();
+
+    while (it.hasNext()) {
+      TrainerFeedbackPrice next = it.next();
+      next.setTrainer(null);
+      it.remove();
+    }
+  }
+
+  public void deleteInterestAreas() {
+    Iterator<TrainerInterestArea> it = interestAreas.iterator();
+
+    while (it.hasNext()) {
+      TrainerInterestArea next = it.next();
+      next.setTrainer(null);
+      it.remove();
+    }
+  }
+
+  public void deleteSns() {
+    Iterator<TrainerSns> it = sns.iterator();
+
+    while (it.hasNext()) {
+      TrainerSns next = it.next();
+      next.setTrainer(null);
+      it.remove();
+    }
+  }
+
+
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/entity/TrainerCareer.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/entity/TrainerCareer.java
@@ -46,4 +46,8 @@ public class TrainerCareer extends BaseEntity {
     this.description = description;
     this.type = type;
   }
+
+  public void setTrainer(Trainer trainer) {
+    this.trainer = trainer;
+  }
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/entity/TrainerFeedbackPrice.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/entity/TrainerFeedbackPrice.java
@@ -2,6 +2,7 @@ package com.cocovo.fitqaspringjava.domain.trainer.entity;
 
 import com.cocovo.fitqaspringjava.domain.BaseEntity;
 import com.cocovo.fitqaspringjava.domain.common.entity.type.WorkOutType;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,10 +27,15 @@ public class TrainerFeedbackPrice extends BaseEntity {
   private WorkOutType.InterestArea interestArea;
   private Integer price;
 
+  @Builder
   public TrainerFeedbackPrice(Trainer trainer, WorkOutType.InterestArea interestArea,
                               Integer price) {
     this.trainer = trainer;
     this.interestArea = interestArea;
     this.price = price;
+  }
+
+  public void setTrainer(Trainer trainer) {
+    this.trainer = trainer;
   }
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/entity/TrainerInterestArea.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/entity/TrainerInterestArea.java
@@ -31,4 +31,8 @@ public class TrainerInterestArea extends BaseEntity {
     this.trainer = trainer;
     this.interestArea = interestArea;
   }
+
+  public void setTrainer(Trainer trainer) {
+    this.trainer = trainer;
+  }
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/entity/TrainerSns.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/entity/TrainerSns.java
@@ -34,4 +34,8 @@ public class TrainerSns extends BaseEntity {
     this.snsType = snsType;
     this.snsUrl = snsUrl;
   }
+
+  public void setTrainer(Trainer trainer) {
+    this.trainer = trainer;
+  }
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/service/TrainerService.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/service/TrainerService.java
@@ -19,5 +19,8 @@ public interface TrainerService {
 
   // update
   TrainerInfo.Main updateTrainerInterestAreas(String trainerToken,
-                                              TrainerCommand.UpdateTrainersByInterestAreas updateInterestAreas);
+                                              TrainerCommand.UpdateTrainerByInterestAreas updateInterestAreas);
+
+  TrainerInfo.Main updateTrainerInfo(String trainerToken,
+                                     TrainerCommand.UpdateTrainerInfo updateTrainerInfo);
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/service/TrainerServiceImpl.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/service/TrainerServiceImpl.java
@@ -6,14 +6,12 @@ import com.cocovo.fitqaspringjava.domain.trainer.component.TrainerReader;
 import com.cocovo.fitqaspringjava.domain.trainer.component.TrainerStore;
 import com.cocovo.fitqaspringjava.domain.trainer.component.TrainerUpdater;
 import com.cocovo.fitqaspringjava.domain.trainer.entity.Trainer;
-import com.cocovo.fitqaspringjava.domain.trainer.entity.TrainerInterestArea;
 import com.cocovo.fitqaspringjava.domain.trainer.mapper.TrainerInfoMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -60,9 +58,19 @@ public class TrainerServiceImpl implements TrainerService {
   @Override
   @Transactional
   public TrainerInfo.Main updateTrainerInterestAreas(String trainerToken,
-                                                     TrainerCommand.UpdateTrainersByInterestAreas updateInterestAreas) {
+                                                     TrainerCommand.UpdateTrainerByInterestAreas updateInterestAreas) {
     var foundTrainer = trainerReader.retrieveTrainerByToken(trainerToken);
     trainerUpdater.updateTrainerInterestAreas(foundTrainer, updateInterestAreas.getInterestAreas());
+    return trainerInfoMapper.of(foundTrainer);
+  }
+
+  @Override
+  @Transactional
+  public TrainerInfo.Main updateTrainerInfo(String trainerToken,
+                                            TrainerCommand.UpdateTrainerInfo updateTrainerInfo) {
+    var foundTrainer = trainerReader.retrieveTrainerByToken(trainerToken);
+    var initUpdateTrainer = updateTrainerInfo.toEntity();
+    trainerUpdater.updateTrainerInfo(foundTrainer, initUpdateTrainer);
     return trainerInfoMapper.of(foundTrainer);
   }
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/infrastructure/trainer/component/TrainerUpdaterImpl.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/infrastructure/trainer/component/TrainerUpdaterImpl.java
@@ -4,7 +4,7 @@ import com.cocovo.fitqaspringjava.domain.common.entity.type.WorkOutType;
 import com.cocovo.fitqaspringjava.domain.trainer.component.TrainerUpdater;
 import com.cocovo.fitqaspringjava.domain.trainer.entity.Trainer;
 import com.cocovo.fitqaspringjava.domain.trainer.entity.TrainerInterestArea;
-import com.cocovo.fitqaspringjava.infrastructure.trainer.repository.TrainerInterestAreaRepository;
+import com.cocovo.fitqaspringjava.infrastructure.trainer.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -39,6 +39,21 @@ public class TrainerUpdaterImpl implements TrainerUpdater {
       trainer.addInterestArea(newTrainerInterestArea);
       trainerInterestAreaRepository.save(newTrainerInterestArea);
     }
+    return true;
+  }
+
+  @Override
+  public boolean updateTrainerInfo(Trainer trainer, Trainer initUpdateTrainer) {
+    trainer.updateName(initUpdateTrainer.getName())
+        .updateStyle(initUpdateTrainer.getStyle())
+        .updateIntroduce(initUpdateTrainer.getIntroduceTitle(), initUpdateTrainer
+            .getIntroduceContext());
+
+    trainer.updateCareers(initUpdateTrainer.getCareers())
+        .updateFeedbackPrices(initUpdateTrainer.getFeedbackPrices())
+        .updateInterestAreas(initUpdateTrainer.getInterestAreas())
+        .updateSns(initUpdateTrainer.getSns());
+
     return true;
   }
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/trainer/controller/TrainerApiController.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/trainer/controller/TrainerApiController.java
@@ -22,6 +22,7 @@ public class TrainerApiController {
   @GetMapping
   public CommonResponse getTrainersAll() {
     var trainers = trainerFacade.retrieveTrainers();
+    System.out.println(trainers);
     var response =
         trainers.stream().map(main -> trainerDtoMapper.of(main)).collect(Collectors.toList());
     System.out.println(response);
@@ -54,10 +55,20 @@ public class TrainerApiController {
   }
 
   @PutMapping("/{trainerToken}/interestAreas")
-  public CommonResponse updateTrainer(@PathVariable(value = "trainerToken") String trainerToken,
-                                      @RequestBody TrainerDto.UpdateTrainerInterestAreasRequest request) {
+  public CommonResponse updateTrainerInterestAreas(
+      @PathVariable(value = "trainerToken") String trainerToken,
+      @RequestBody TrainerDto.UpdateTrainerInterestAreasRequest request) {
     var updatedTrainer =
         trainerFacade.updateTrainerInterestAreas(trainerToken, trainerDtoMapper.of(request));
+    var response = trainerDtoMapper.of(updatedTrainer);
+    return CommonResponse.success(response);
+  }
+
+  @PutMapping("/{trainerToken}")
+  public CommonResponse updateTrainerInfo(@PathVariable(value = "trainerToken") String trainerToken,
+                                          @RequestBody @Valid TrainerDto.UpdateTrainerInfoRequest request) {
+    var updatedTrainer =
+        trainerFacade.updateTrainerInfo(trainerToken, trainerDtoMapper.of(request));
     var response = trainerDtoMapper.of(updatedTrainer);
     return CommonResponse.success(response);
   }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/trainer/dto/TrainerDto.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/trainer/dto/TrainerDto.java
@@ -2,9 +2,7 @@ package com.cocovo.fitqaspringjava.interfaces.trainer.dto;
 
 import com.cocovo.fitqaspringjava.domain.common.TypeInfo;
 import com.cocovo.fitqaspringjava.domain.trainer.entity.TrainerCareer;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -42,10 +40,24 @@ public class TrainerDto {
     private List<TypeInfo.InterestArea> interestAreas;
   }
 
+  @Getter
+  @ToString
+  @RequiredArgsConstructor
+  public static class UpdateTrainerInfoRequest {
+    private String name;
+    private TypeInfo.WorkOutStyle style;
+    private String introduceTitle;
+    private String introduceContext;
+    private List<TrainerCareerInfo> careers;
+    private List<TrainerFeedbackPriceInfo> feedbackPrices;
+    private List<TrainerInterestAreaInfo> interestAreas;
+    private List<TrainerSnsInfo> sns;
+  }
+
   // Domain
   @Getter
-  @Builder
   @ToString
+  @Builder
   public static class Main {
     private final String trainerToken;
     private final String name;
@@ -63,39 +75,48 @@ public class TrainerDto {
   }
 
   @Getter
-  @Builder
   @ToString
+  @Builder
   public static class TrainerImageInfo {
     private final String imageUrl;
     private final TypeInfo.ImageType imageType;
   }
 
   @Getter
-  @Builder
   @ToString
+  @Builder
   public static class TrainerCareerInfo {
     private final String description;
     private final TrainerCareer.Type type;
   }
 
   @Getter
-  @Builder
   @ToString
+  @Builder
   public static class TrainerFeedbackPriceInfo {
-    private final TypeInfo.InterestArea interestArea;
+    private final TypeInfo.InterestArea area;
     private final Integer price;
   }
 
   @Getter
-  @Builder
   @ToString
   public static class TrainerInterestAreaInfo {
-    private final TypeInfo.InterestArea interestArea;
+    private TypeInfo.InterestArea interestArea;
+
+    public TrainerInterestAreaInfo() { }
+
+    public TrainerInterestAreaInfo(TypeInfo.InterestArea interestArea) {
+      this.interestArea = interestArea;
+    }
+
+    public void setInterestArea(TypeInfo.InterestArea interestArea) {
+      this.interestArea = interestArea;
+    }
   }
 
   @Getter
-  @Builder
   @ToString
+  @Builder
   public static class TrainerSnsInfo {
     private final TypeInfo.SnsType snsType;
     private final String snsUrl;

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/trainer/mapper/TrainerDtoMapper.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/trainer/mapper/TrainerDtoMapper.java
@@ -5,6 +5,7 @@ import com.cocovo.fitqaspringjava.domain.trainer.TrainerInfo;
 import com.cocovo.fitqaspringjava.interfaces.trainer.dto.TrainerDto;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR,
@@ -32,5 +33,15 @@ public interface TrainerDtoMapper {
   TrainerDto.TrainerSnsInfo of(TrainerInfo.TrainerSnsInfo trainerSnsInfo);
 
   // update
-  TrainerCommand.UpdateTrainersByInterestAreas of(TrainerDto.UpdateTrainerInterestAreasRequest request);
+  TrainerCommand.UpdateTrainerByInterestAreas of(TrainerDto.UpdateTrainerInterestAreasRequest request);
+
+  TrainerCommand.UpdateTrainerInfo of(TrainerDto.UpdateTrainerInfoRequest request);
+
+  TrainerCommand.UpdateTrainerCareer of(TrainerDto.TrainerCareerInfo request);
+
+  TrainerCommand.UpdateFeedbackPrice of(TrainerDto.TrainerFeedbackPriceInfo request);
+
+  TrainerCommand.UpdateInterestArea of(TrainerDto.TrainerInterestAreaInfo request);
+
+  TrainerCommand.UpdateSns of(TrainerDto.TrainerSnsInfo request);
 }


### PR DESCRIPTION
**변경 내용**
- [x] 트레이너 도메인에 대표 이력(`representativeFootprints`)를 추가
- [x] 트레이너 도메인에 대표 경력(`representativeCareer`)를 추가
- [x] 트레이너 커리어에 `String`과 `Type(Career, License)`를 갖도록 수정
- [x] 프론트에서 트레이너 정보를 수정하는 기능의 Api를 추가

```java
  @PutMapping("/{trainerToken}/interestAreas")
  public CommonResponse updateTrainer(@PathVariable(value = "trainerToken") String trainerToken,
                                      @RequestBody TrainerDto.UpdateTrainerInterestAreasRequest request) {
    var updatedTrainer =
        trainerFacade.updateTrainerInterestAreas(trainerToken, trainerDtoMapper.of(request));
    var response = trainerDtoMapper.of(updatedTrainer);
    return CommonResponse.success(response);
  }
```
```http
PUT http://localhost:8080/api/v1/trainers/trn_EfF1W4nfWsOoDx49/
Content-Type: application/json

{
  "name": "name333",
  "style": "BODY_BUILDING",
  "introduceTitle": "소개 제목을 변경합니다777",
  "introduceContext": "소개 내용을 변경합니다777",
  "careers": [
    {
      "description": "1번 경력입니다.",
      "type": "CAREER"
    }
  ],
  "feedbackPrices": [
    {
      "area": "LOWER",
      "price": 6000
    }
  ],
  "interestAreas": [
    {
      "interestArea": "CHEST"
    },
    {
      "interestArea": "SHOULDER"
    }
  ],
  "sns": [
    {
      "snsUrl": "Sns 3 Url",
      "snsType": "INSTAGRAM"
    }
  ]
}
```

**CascadeType.REMOVE**, **orphanRemoval** 를 수정했음

**CascadeType.REMOVE**는 @OneToMany에서 One이 삭제되었을 때 Many가 삭제되도록 함
**orphanRemoval**은 Many에서 외래키를 null로 변경이되면 데이터를 삭제하도록 함

도메인에서 OneToMany 데이터를 삭제할 때  
1. Many의 One의 값을 null로 변경
2. One에서 들고 있는 Many를 삭제
3. 1, 2번을 @Transaction으로 감싸기로 처리함