### PR TITLE
Enable getTrainerFeedbacks api

### DIFF
--- a/spring/fitqa-spring-java/http-test/trainer-api.http
+++ b/spring/fitqa-spring-java/http-test/trainer-api.http
@@ -1,21 +1,35 @@
 ###
 # 모든 Trainer 들을 가져옵니다
-
+# TrainerApiController::getTrainersAll
 GET http://localhost:8080/api/v1/trainers
 Accept: application/json
 
 ###
-# InterestAreas가 일치하는 Trainer 들을 가져옵니다.
-
-GET http://localhost:8080/api/v1/trainers?interestAreas="LOWER"&interestAreas="BACK"
-###
 # 특정 Trainer의 정보를 가져옵니다
+# TrainerApiController::getTrainerById
 
 GET http://localhost:8080/api/v1/trainers/trn_qQYHg782nZ4qKC3i
 Accept: application/json
 
 ###
+# 트레이너와 관련된 피드백 리스트를 가져옵니다
+# TrainerApiController::getTrainerFeedbacks
+
+GET http://localhost:8080/api/v1/trainers/trn_YC9zWA8gVBmzo5uQ/feedbacks
+Accept: application/json
+
+
+###
+# InterestAreas가 일치하는 Trainer 들을 가져옵니다.
+# TrainerApiController::getTrainerByInterestAreas
+
+GET http://localhost:8080/api/v1/trainers?interestAreas="LOWER"&interestAreas="BACK"
+Accept: application/json
+
+###
 # 트레이너를 등록합니다
+# TrainerApiController::registerTrainer
+
 POST http://localhost:8080/api/v1/trainers
 Content-Type: application/json
 
@@ -26,6 +40,7 @@ Content-Type: application/json
 
 ###
 # 트레이너의 관심 부위 정보를 변경합니다
+# TrainerApiController::updateTrainerInterestAreas
 
 PUT http://localhost:8080/api/v1/trainers/trn_EfF1W4nfWsOoDx49/interestAreas
 Content-Type: application/json
@@ -39,6 +54,7 @@ Content-Type: application/json
 
 ###
 # 트레이너의 정보를 변경합니다.
+# TrainerApiController::updateTrainerInfo
 
 PUT http://localhost:8080/api/v1/trainers/trn_EfF1W4nfWsOoDx49/
 Content-Type: application/json

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/application/trainer/TrainerFacade.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/application/trainer/TrainerFacade.java
@@ -1,6 +1,8 @@
 package com.cocovo.fitqaspringjava.application.trainer;
 
 
+import com.cocovo.fitqaspringjava.domain.feedback.FeedbackInfo;
+import com.cocovo.fitqaspringjava.domain.feedback.service.FeedbackService;
 import com.cocovo.fitqaspringjava.domain.trainer.TrainerCommand;
 import com.cocovo.fitqaspringjava.domain.trainer.TrainerInfo;
 import com.cocovo.fitqaspringjava.domain.trainer.service.TrainerService;
@@ -15,6 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TrainerFacade {
   private final TrainerService trainerService;
+  private final FeedbackService feedbackService;
 
   public String registerTrainer(TrainerCommand.RegisterTrainer registerTrainer) {
     return trainerService.registerTrainer(registerTrainer);
@@ -31,6 +34,11 @@ public class TrainerFacade {
 
   public List<TrainerInfo.Main> retrieveTrainers() {
     return trainerService.retrieveTrainers();
+  }
+
+  public List<FeedbackInfo.Main> getFeedbacksOfTrainer(String trainerToken) {
+    var trainer = trainerService.retrieveTrainerByToken(trainerToken);
+    return feedbackService.retrieveFeedbacksByTrainerId(trainer.getId());
   }
 
   public TrainerInfo.Main updateTrainerInterestAreas(String trainerToken,

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/feedback/FeedbackCommand.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/feedback/FeedbackCommand.java
@@ -14,7 +14,7 @@ public class FeedbackCommand {
     @ToString
     public static class RegisterFeedback {
         private String ownerId;
-        private String trainerId;
+        private Long trainerId;
         private TypeInfo.InterestArea interestArea;
         private Integer price;
         private String title;

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/feedback/component/FeedbackReader.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/feedback/component/FeedbackReader.java
@@ -8,4 +8,6 @@ public interface FeedbackReader {
     List<Feedback> retrieveFeedbackAll();
 
     Feedback retrieveFeedbackByToken(String feedbackToken);
+
+    List<Feedback> retrieveFeedbackAllByTrainerId(Long trainerId);
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/feedback/entity/Feedback.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/feedback/entity/Feedback.java
@@ -28,7 +28,7 @@ public class Feedback extends BaseEntity {
     private String feedbackToken;
 
     private String ownerId;
-    private String trainerId;
+    private Long trainerId;
     @Enumerated(EnumType.STRING)
     private TypeInfo.InterestArea interestArea;
     private Integer price;
@@ -54,9 +54,9 @@ public class Feedback extends BaseEntity {
     }
 
     @Builder
-    public Feedback(String ownerId, String trainerId, TypeInfo.InterestArea interestArea, Integer price, String title, String content, boolean locked) {
+    public Feedback(String ownerId, Long trainerId, TypeInfo.InterestArea interestArea,
+                    Integer price, String title, String content, boolean locked) {
         if (StringUtils.isEmpty(ownerId)) throw new InvalidParamException("ownerId cannot be empty.");
-        if (StringUtils.isEmpty(trainerId)) throw new InvalidParamException("trainerToken cannot be empty.");
         if (price < 0) throw new InvalidParamException("price cannot be below 0");
         if (StringUtils.isEmpty(title)) throw new InvalidParamException("title cannot be empty.");
         if (StringUtils.isEmpty(content)) throw new InvalidParamException("content cannot be empty.");

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/feedback/service/FeedbackService.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/feedback/service/FeedbackService.java
@@ -9,6 +9,9 @@ public interface FeedbackService {
 
     List<FeedbackInfo.Main> retrieveFeedbacks();
     FeedbackInfo.Main retrieveFeedbackByToken(String feedbackToken);
+
+    List<FeedbackInfo.Main> retrieveFeedbacksByTrainerId(Long trainerId);
+
     FeedbackInfo.Main registerFeedback(FeedbackCommand.RegisterFeedback command);
 
     String addComment(String feedbackToken, FeedbackCommand.AddComment command);

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/feedback/service/FeedbackServiceImpl.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/feedback/service/FeedbackServiceImpl.java
@@ -38,6 +38,14 @@ public class FeedbackServiceImpl implements FeedbackService {
     }
 
     @Override
+    public List<FeedbackInfo.Main> retrieveFeedbacksByTrainerId(Long trainerId) {
+        var feedbacks = feedbackReader.retrieveFeedbackAllByTrainerId(trainerId);
+        return feedbacks.stream()
+                .map(feedbackInfoMapper::of)
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public FeedbackInfo.Main registerFeedback(FeedbackCommand.RegisterFeedback command) {
         var initFeedback = command.toEntity();
         var feedback = feedbackStore.store(initFeedback);

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/TrainerInfo.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/TrainerInfo.java
@@ -16,6 +16,7 @@ public class TrainerInfo {
   @Builder
   @ToString
   public static class Main {
+    private final Long id;
     private final String trainerToken;
     private final String name;
     private final WorkOutType.Style style;

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/infrastructure/feedback/component/FeedbackReaderImpl.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/infrastructure/feedback/component/FeedbackReaderImpl.java
@@ -26,4 +26,9 @@ public class FeedbackReaderImpl implements FeedbackReader {
         return feedbackRepository.findByFeedbackToken(feedbackToken)
                 .orElseThrow(EntityNotFoundException::new);
     }
+
+    @Override
+    public List<Feedback> retrieveFeedbackAllByTrainerId(Long trainerId) {
+        return feedbackRepository.findAllByTrainerId(trainerId);
+    }
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/infrastructure/feedback/repository/FeedbackRepository.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/infrastructure/feedback/repository/FeedbackRepository.java
@@ -4,10 +4,12 @@ import com.cocovo.fitqaspringjava.domain.feedback.entity.Feedback;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     Optional<Feedback> findByFeedbackToken(String feedbackToken);
 
+    List<Feedback> findAllByTrainerId(Long trainerId);
 }

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/trainer/controller/TrainerApiController.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/trainer/controller/TrainerApiController.java
@@ -2,6 +2,7 @@ package com.cocovo.fitqaspringjava.interfaces.trainer.controller;
 
 import com.cocovo.fitqaspringjava.application.trainer.TrainerFacade;
 import com.cocovo.fitqaspringjava.common.response.CommonResponse;
+import com.cocovo.fitqaspringjava.interfaces.feedback.FeedbackDtoMapper;
 import com.cocovo.fitqaspringjava.interfaces.trainer.dto.TrainerDto;
 import com.cocovo.fitqaspringjava.interfaces.trainer.mapper.TrainerDtoMapper;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
 public class TrainerApiController {
   private final TrainerFacade trainerFacade;
   private final TrainerDtoMapper trainerDtoMapper;
+  private final FeedbackDtoMapper feedbackDtoMapper;
 
   @GetMapping
   public CommonResponse getTrainersAll() {
@@ -34,6 +36,15 @@ public class TrainerApiController {
     var trainerInfo = trainerFacade.retrieveTrainerInfo(trainerToken);
     var trainerResponse = trainerDtoMapper.of(trainerInfo);
     return CommonResponse.success(trainerResponse);
+  }
+
+  @GetMapping("/{trainerToken}/feedbacks")
+  public CommonResponse getTrainerFeedbacks(@PathVariable("trainerToken") String trainerToken) {
+    var feedbacks = trainerFacade.getFeedbacksOfTrainer(trainerToken);
+    var response = feedbacks.stream()
+            .map(feedbackDtoMapper::of)
+            .collect(Collectors.toList());
+    return CommonResponse.success(response);
   }
 
   @GetMapping(params = "interestAreas")


### PR DESCRIPTION
**변경 내용**
- [x] `Trainer`와 관련된 `Feedback` 리스트를 가져오는 api를 추가
- [x] `Feedback` 도메인의 `trainerId`의 데이터 타입을 `String`에서 `Long`으로 변경

```java
  // TrainerApiController
  @GetMapping("/{trainerToken}/feedbacks")
  public CommonResponse getTrainerFeedbacks(@PathVariable("trainerToken") String trainerToken) {
    var feedbacks = trainerFacade.getFeedbacksOfTrainer(trainerToken);
    var response = feedbacks.stream()
            .map(feedbackDtoMapper::of)
            .collect(Collectors.toList());
    return CommonResponse.success(response);
  }
```
```java
  // TrainerFacade
  public List<FeedbackInfo.Main> getFeedbacksOfTrainer(String trainerToken) {
    var trainer = trainerService.retrieveTrainerByToken(trainerToken);
    return feedbackService.retrieveFeedbacksByTrainerId(trainer.getId());
  }
```