### PR TITLE
Hotfix/update time stamp

### DIFF
--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/BaseEntity.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/BaseEntity.java
@@ -2,6 +2,7 @@ package com.cocovo.fitqaspringjava.domain;
 
 import lombok.Getter;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.EntityListeners;
@@ -16,6 +17,6 @@ public class BaseEntity {
   @CreationTimestamp
   private ZonedDateTime createdAt;
 
-  @CreationTimestamp
+  @UpdateTimestamp
   private ZonedDateTime updatedAt;
 }


### PR DESCRIPTION
**변경 내용**
- `BaseEntity`의 `createdAt`, `updatedAt`이 똑같이 `@CreationTimestamp`로 되어있어서 하나를 `update`에 맞춰서 수정함.

``` java
public class BaseEntity {

  @CreationTimestamp
  private ZonedDateTime createdAt;

  @UpdateTimestamp
  private ZonedDateTime updatedAt;
}
```
