### PR TITLE
Hotfix: Remove infinite loop between trainer and feedback domain

### DIFF
--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/feedback/FeedbackInfo.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/feedback/FeedbackInfo.java
@@ -1,6 +1,7 @@
 package com.cocovo.fitqaspringjava.domain.feedback;
 
 import com.cocovo.fitqaspringjava.domain.common.TypeInfo;
+import com.cocovo.fitqaspringjava.domain.common.entity.type.WorkOutType;
 import com.cocovo.fitqaspringjava.domain.feedback.entity.Feedback;
 import com.cocovo.fitqaspringjava.domain.trainer.TrainerInfo;
 import com.cocovo.fitqaspringjava.domain.user.UserInfo;
@@ -20,7 +21,7 @@ public class FeedbackInfo {
     public static class Main {
         private final String feedbackToken;
         private final UserInfo.Main owner;
-        private final TrainerInfo.Main trainer;
+        private final FeedbackTrainer trainer;
         private final TypeInfo.InterestArea interestArea;
         private final Integer price;
         private final String title;
@@ -31,6 +32,27 @@ public class FeedbackInfo {
         private final Feedback.Status status;
         private final ZonedDateTime createdAt;
         private final ZonedDateTime updatedAt;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class FeedbackTrainer {
+        private final Long id;
+        private final String trainerToken;
+        private final String name;
+        private final String email;
+        private final WorkOutType.Style style;
+        private final String introduceTitle;
+        private final String introduceContext;
+        private final String representativeCareer;
+        private final String representativeFootprints;
+        private final Integer likesCount;
+        private final List<TrainerInfo.TrainerImageInfo> images;
+        private final List<TrainerInfo.TrainerCareerInfo> careers;
+        private final List<TrainerInfo.TrainerFeedbackPriceInfo> feedbackPrices;
+        private final List<TrainerInfo.TrainerInterestAreaInfo> interestAreas;
+        private final List<TrainerInfo.TrainerSnsInfo> sns;
     }
 
     @Getter

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/TrainerInfo.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/TrainerInfo.java
@@ -1,14 +1,18 @@
 package com.cocovo.fitqaspringjava.domain.trainer;
 
+import com.cocovo.fitqaspringjava.domain.common.TypeInfo;
 import com.cocovo.fitqaspringjava.domain.common.entity.type.ImageType;
 import com.cocovo.fitqaspringjava.domain.common.entity.type.SnsType;
 import com.cocovo.fitqaspringjava.domain.common.entity.type.WorkOutType;
 import com.cocovo.fitqaspringjava.domain.feedback.FeedbackInfo;
+import com.cocovo.fitqaspringjava.domain.feedback.entity.Feedback;
 import com.cocovo.fitqaspringjava.domain.trainer.entity.*;
+import com.cocovo.fitqaspringjava.domain.user.UserInfo;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 
 public class TrainerInfo {
@@ -33,7 +37,25 @@ public class TrainerInfo {
     private final List<TrainerFeedbackPriceInfo> feedbackPrices;
     private final List<TrainerInterestAreaInfo> interestAreas;
     private final List<TrainerSnsInfo> sns;
-    private final List<FeedbackInfo.Main> feedbacks;
+    private final List<TrainerFeedback> feedbacks;
+  }
+
+  @Getter
+  @Builder
+  @ToString
+  public static class TrainerFeedback {
+    private final String feedbackToken;
+    private final UserInfo.Main owner;
+    private final TypeInfo.InterestArea interestArea;
+    private final Integer price;
+    private final String title;
+    private final String content;
+    private final boolean locked;
+    private final List<FeedbackInfo.FeedbackCommentInfo> comments;
+    private final FeedbackInfo.FeedbackAnswerInfo answer;
+    private final Feedback.Status status;
+    private final ZonedDateTime createdAt;
+    private final ZonedDateTime updatedAt;
   }
 
   @Getter

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/mapper/TrainerInfoMapper.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/domain/trainer/mapper/TrainerInfoMapper.java
@@ -1,10 +1,12 @@
 package com.cocovo.fitqaspringjava.domain.trainer.mapper;
 
 import com.cocovo.fitqaspringjava.domain.feedback.component.FeedbackInfoMapper;
+import com.cocovo.fitqaspringjava.domain.feedback.entity.Feedback;
 import com.cocovo.fitqaspringjava.domain.trainer.TrainerInfo;
 import com.cocovo.fitqaspringjava.domain.trainer.entity.*;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR,
@@ -12,6 +14,10 @@ import org.mapstruct.ReportingPolicy;
 public interface TrainerInfoMapper {
 
   TrainerInfo.Main of(Trainer trainer);
+
+  @Mapping(source = "feedbackCommentList", target = "comments")
+  @Mapping(source = "feedbackAnswer", target = "answer")
+  TrainerInfo.TrainerFeedback of(Feedback feedback);
 
   TrainerInfo.TrainerImageInfo of(TrainerImage trainerImage);
 

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/feedback/FeedbackDto.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/feedback/FeedbackDto.java
@@ -63,7 +63,7 @@ public class FeedbackDto {
     public static class Main {
         private final String feedbackToken;
         private final UserDto.Main owner;
-        private final TrainerDto.Simple trainer;
+        private final FeedbackTrainer trainer;
         private final TypeInfo.InterestArea interestArea;
         private final Integer price;
         private final String title;
@@ -75,6 +75,27 @@ public class FeedbackDto {
         private final ZonedDateTime createdAt;
         private final ZonedDateTime updatedAt;
     }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class FeedbackTrainer {
+        private final String trainerToken;
+        private final String name;
+        private final String email;
+        private final TypeInfo.WorkOutStyle style;
+        private final String introduceTitle;
+        private final String introduceContext;
+        private final String representativeCareer;
+        private final String representativeFootprints;
+        private final Integer likesCount;
+        private final List<TrainerDto.TrainerImageInfo> images;
+        private final List<TrainerDto.TrainerCareerInfo> careers;
+        private final List<TrainerDto.TrainerFeedbackPriceInfo> feedbackPrices;
+        private final List<TrainerDto.TrainerInterestAreaInfo> interestAreas;
+        private final List<TrainerDto.TrainerSnsInfo> sns;
+    }
+
 
 
     @Getter

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/trainer/dto/TrainerDto.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/trainer/dto/TrainerDto.java
@@ -1,12 +1,15 @@
 package com.cocovo.fitqaspringjava.interfaces.trainer.dto;
 
 import com.cocovo.fitqaspringjava.domain.common.TypeInfo;
+import com.cocovo.fitqaspringjava.domain.feedback.entity.Feedback;
 import com.cocovo.fitqaspringjava.domain.trainer.entity.TrainerCareer;
 import com.cocovo.fitqaspringjava.interfaces.feedback.FeedbackDto;
+import com.cocovo.fitqaspringjava.interfaces.user.UserDto;
 import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 public class TrainerDto {
@@ -68,7 +71,6 @@ public class TrainerDto {
   @ToString
   @Builder
   public static class Main {
-
     private final String trainerToken;
     private final String name;
     private final String email;
@@ -87,19 +89,21 @@ public class TrainerDto {
   }
 
   @Getter
-  @ToString
   @Builder
-  public static class Simple {
-    private final String trainerToken;
-    private final String name;
-    private final String email;
-    private final TypeInfo.WorkOutStyle style;
-    private final String introduceTitle;
-    private final String introduceContext;
-    private final String representativeCareer;
-    private final String representativeFootprints;
-    private final Integer likesCount;
-    private final List<TrainerImageInfo> images;
+  @ToString
+  public static class TrainerFeedback {
+    private final String feedbackToken;
+    private final UserDto.Main owner;
+    private final TypeInfo.InterestArea interestArea;
+    private final Integer price;
+    private final String title;
+    private final String content;
+    private final boolean locked;
+    private final List<FeedbackDto.FeedbackCommentInfo> comments;
+    private final FeedbackDto.FeedbackAnswerInfo answer;
+    private final Feedback.Status status;
+    private final ZonedDateTime createdAt;
+    private final ZonedDateTime updatedAt;
   }
 
   @Getter

--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/trainer/mapper/TrainerDtoMapper.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/trainer/mapper/TrainerDtoMapper.java
@@ -9,7 +9,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR,
-    unmappedTargetPolicy = ReportingPolicy.ERROR)
+    unmappedTargetPolicy = ReportingPolicy.WARN)
 public interface TrainerDtoMapper {
 
   // register


### PR DESCRIPTION
**기존 문제상황**
- `trainer`는 `feedback`을 참조하고, `feedback`은 `trainer`를 참조하는 관계가 되서 `stackoverflow` 발생

**변경 내용**
- `trainerInfo`에서 `feedback` 도메인의 `info` 객체 `TrainerFeedback`을 만들어서 사용.
- 마찬가지로 `feedbackInfo`에도 `FeedbackTrainer`를 만들어서 사용.
- `DTO`에서도 똑같이 작업함