### PR TITLE
Hotfix: Add auth success gateway

### DIFF
--- a/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/user/UserApiController.java
+++ b/spring/fitqa-spring-java/src/main/java/com/cocovo/fitqaspringjava/interfaces/user/UserApiController.java
@@ -38,6 +38,11 @@ public class UserApiController {
     return CommonResponse.success(response);
   }
 
+  @GetMapping("/success")
+  public CommonResponse authSuccess() {
+    return CommonResponse.success("success");
+  }
+
   @GetMapping("/failed")
   public CommonResponse authFailed() {
     return CommonResponse.fail(ErrorCode.USER_AUTH_FAILED);


### PR DESCRIPTION
**기존 문제상황**
- 로그인 완료 후 `redirect`하는 곳이 없어서 에러가 발생하고 있었음
- 기능상의 문제는 없지만 `Exception`이 발생하고 있었음

**변경 내용**
- [x] 로그인 성공하면 `success` 텍스트를 출력하도록 함
