### PR TITLE
Feat: Add docker file

### DIFF
--- a/spring/fitqa-spring-java/Dockerfile
+++ b/spring/fitqa-spring-java/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-alpine
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
`Dockerfile` 만들기

[참고 링크](https://spring.io/guides/gs/spring-boot-docker/)

# 도커 빌드방법
1. `./gradlew build` (터미널에서 하거나 `Android Studio`에서 하면 됨)
2. `docker build -t fitqa/fitqa-spring java .`
3. `docker run -p 8080:8080 -t fitqa/fitqa-spring java` (테스트 해보기)
4. `docker push fitqa/fitqa-spring-java:tagname`